### PR TITLE
Reworking container naming

### DIFF
--- a/ansible/roles/basic-os/tasks/basic-os.yml
+++ b/ansible/roles/basic-os/tasks/basic-os.yml
@@ -4,7 +4,6 @@
       - podman
       - jq
       - curl
-      - xxd
       - acl
     state: latest
 

--- a/ansible/roles/runner/files/make_env.sh.j2
+++ b/ansible/roles/runner/files/make_env.sh.j2
@@ -4,4 +4,4 @@ env_file_path=/home/github/.{{item.name}}-meshtastic.env
 bearer={{ github_token }}
 
 TOKEN=$(curl -L -sS -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $bearer" -H "X-GitHub-Api-Version: 2022-11-28"   https://api.github.com/orgs/meshtastic/actions/runners/registration-token | jq '.token')
-printf "export UID_RANDOM=`xxd -p -l2 /dev/urandom`\nexport TOKEN=$TOKEN\n" | tr -d '"' > $env_file_path
+printf "export TOKEN=$TOKEN\n" | tr -d '"' > $env_file_path

--- a/ansible/roles/runner/tasks/github-runner.yml
+++ b/ansible/roles/runner/tasks/github-runner.yml
@@ -35,7 +35,7 @@
     command: 
       - /bin/bash
       - -c
-      - 'alias docker="podman"; source /.runner-meshtastic.env; cd; source bin/activate; cd runner; ./config.sh --url https://github.com/meshtastic --token $TOKEN --ephemeral --disableupdate --labels ubuntu-latest,{{ user_nickname }} --unattended --replace --name {{user_nickname}}-{{ item.runner_location }} --runnergroup Mesh-x86 --work _work; ./run.sh'
+      - 'alias docker="podman"; source /.runner-meshtastic.env; cd; source bin/activate; cd runner; ./config.sh --url https://github.com/meshtastic --token $TOKEN --ephemeral --disableupdate --labels ubuntu-latest,{{ user_nickname }} --unattended --replace --name {{user_nickname}}-{{ item.runner_location }}-{{item.name}} --runnergroup Mesh-x86 --work _work; ./run.sh'
     state: present
     volumes:
       - "/home/github/.{{item.name}}-meshtastic.env:/.runner-meshtastic.env"


### PR DESCRIPTION
* Added runner's name in runner's container naming argument to allow multiple runners per `runner_location`
* Cleaned up old UID_RANDOM requirements